### PR TITLE
Eventemitter4 Fix

### DIFF
--- a/lib/rpc-socket.js
+++ b/lib/rpc-socket.js
@@ -158,7 +158,12 @@ RpcSocket.prototype.rpc=function(messageType,userData,replyHandler) {
  * @returns {void} nothing.
  */
 RpcSocket.prototype.close=function() {
-        this.removeAllListeners();
+        /* Eventemitter4 Fix for this.removeAllListeners(); */
+        this.listeners={};
+        this.onceListeners={};
+        this.listenersToAnyEvent=[];
+        this.event=null;
+        
         this.webSocket.close();
 }
 


### PR DESCRIPTION
Quick fix to be able to call ws.close() without errors. Issue with Eventemitter4 library.